### PR TITLE
Allow building from a Pipfile or requirements.txt

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,24 +14,10 @@ environment:
     - PYTHON: "C:\\Python34"
       PYTHON_VERSION: "3.4.6"
       PYTHON_ARCH: "32"
-      
-    - PYTHON: "C:\\Python33"
-      PYTHON_VERSION: "3.5.3"
-      PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.13"
       PYTHON_ARCH: "64"
-
-#    - PYTHON: "C:\\Python33-x64"
-#      PYTHON_VERSION: "3.4.6"
-#      PYTHON_ARCH: "64"
-#      WINDOWS_SDK_VERSION: "v7.1"
-
-#    - PYTHON: "C:\\Python34-x64"
-#      PYTHON_VERSION: "3.5.3"
-#      PYTHON_ARCH: "64"
-#      WINDOWS_SDK_VERSION: "v7.1"
 
 matrix:
   fast_finish: true

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python
 from setuptools import setup, find_packages, Extension  # This setup relies on setuptools since distutils is insufficient and badly hacked code
-import numpy as np
+from setuptools.command.build_ext import build_ext as _build_ext
+
+class build_ext(_build_ext):
+    def finalize_options(self):
+        _build_ext.finalize_options(self)
+        # Prevent numpy from thinking it is still in its setup process:
+        __builtins__.__NUMPY_SETUP__ = False
+        import numpy
+        self.include_dirs.append(numpy.get_include())
 
 # Check if cython exists, then use it. Otherwise compile already cythonized cpp file
 have_cython = False
@@ -17,11 +25,12 @@ else:
                                sources=['pyLandau/cpp/pylandau.cpp'],
                                language="c++")]
 
-version = '2.1.0'
+version = '2.1.1'
 author = 'David-Leon Pohl'
 author_email = 'pohl@physik.uni-bonn.de'
 
-install_requires = ['cython', 'numpy']
+install_requires = ['cython', 'numpy'] # scipy
+setup_requires = ['numpy', 'cython']
 
 setup(
     name='pylandau',
@@ -34,12 +43,13 @@ setup(
     maintainer=author,
     author_email=author_email,
     maintainer_email=author_email,
+    cmdclass={'build_ext':build_ext},
     install_requires=install_requires,
+    setup_requires=setup_requires,
     packages=find_packages(),
     include_package_data=True,  # accept all data files and directories matched by MANIFEST.in or found in source control
     package_data={'': ['README.*', 'VERSION'], 'docs': ['*'], 'examples': ['*']},
     ext_modules=cpp_extension,
-    include_dirs=[np.get_include()],
     keywords=['Landau', 'Langau', 'PDF'],
     platforms='any'
 )


### PR DESCRIPTION
Currently, you can't include pylandau in a requirements listing for a virtual environment, like `pipenv`, since it requires that numpy be pre-installed. This patch should lift that requirement.