### PR TITLE
CI: Build wheels on CI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,56 @@
+name: Build wheels
+
+on:
+  release
+
+jobs:
+  build_wheels:
+    name: Build wheels for python ${{matrix.python-version}} on (${{matrix.os}})
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-11]
+        python-version: [3.7, 3.8, 3.9]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Anaconda ${{matrix.python-version}}
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
+        python-version: ${{matrix.python-version}}
+
+    - name: Install dependencies
+      shell: bash -l {0}
+      run: |
+        conda info -a
+        conda install cython numpy
+    - name: Install cibuildwheel
+      shell: bash -l {0}
+      run: |
+        pip install cibuildwheel
+    - name: Build wheels
+      shell: bash -l {0}
+      run: python -m cibuildwheel --output-dir wheels
+      env:
+        - CIBW_ARCHS: auto64
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ./wheels/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          cache: 'pip'
+
+      - name: Build sdist
+        run: python -m build --sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz


### PR DESCRIPTION
Build wheels for Ubuntu, Windows and macOS using Github Actions whenever a new release is happening.