### PR TITLE
Numba support in pylandau environment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,9 +25,9 @@ jobs:
       with:
         python-version: ${{matrix.python-version}}
         cache: 'pip'
-    - name: Install dependencies
-      run: pip install cython numpy scipy hypothesis pytest
     - name: Install package
       run: pip install -e .
+    - name: Install test dependencies
+      run: pip install hypothesis pytest
     - name: Run tests
       run: pytest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,12 +20,14 @@ jobs:
       env:
         CIBW_ARCHS: auto64  # Build 64bit versions only
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-        CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux2014"
-        CIBW_BUILD: "cp38-* cp39-* cp310-*"  # Build on CPython 3.8 - 3.10 only
+        CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
+        CIBW_BUILD: cp38-* cp39-* cp310-*  # Build on CPython 3.8 - 3.10 only
         CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
         CIBW_SKIP: "*-manylinux_i686 *_ppc64le *_s390x *-musllinux*"
         CIBW_ARCHS_MACOS: x86_64 arm64
-        CIBW_TEST_COMMAND: "echo Wheel installed"
+        CIBW_TEST_REQUIRES: hypothesis pytest
+        CIBW_TEST_COMMAND: pytest {package}/tests
+        CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
 
     - uses: actions/upload-artifact@v2
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = 'pylandau'
 version = '2.2.0'
 description = 'A Landau PDF definition to be used in Python.'
 license = {file = 'LICENSE'}
-requires-python = '>=3.7'
+requires-python = '>=3.8'
 readme = 'README.md'
 authors = [
     {name = 'David-Leon Pohl', email = 'pohl@physik.uni-bonn.de'}, 
@@ -11,6 +11,11 @@ authors = [
 ]
 maintainers = [ 
     {name = 'Christian Bespin', email = 'bespin@physik.uni-bonn.de'}
+]
+dependencies = [
+  "cython>=0.29",
+  "numpy>=1.21",
+  "scipy>=1.7",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,21 +2,26 @@
 name = 'pylandau'
 version = '2.2.0'
 description = 'A Landau PDF definition to be used in Python.'
-repository = 'https://github.com/SiLab-Bonn/pyLandau'
-license = 'LGPL-2.1-only'
-python = '^3.8'
+license = {file = 'LICENSE'}
+requires-python = '>=3.7'
 readme = 'README.md'
-authors = 'David-Leon Pohl, Christian Bespin'
-maintainers  ='David-Leon Pohl, Christian Bespin'
-author_email = 'pohl@physik.uni-bonn.de, bespin@physik.uni-bonn.de'
-maintainer_email = 'pohl@physik.uni-bonn.de, bespin@physik.uni-bonn.de'
+authors = [
+    {name = 'David-Leon Pohl', email = 'pohl@physik.uni-bonn.de'}, 
+    {name = 'Christian Bespin', email = 'bespin@physik.uni-bonn.de'}
+]
+maintainers = [ 
+    {name = 'Christian Bespin', email = 'bespin@physik.uni-bonn.de'}
+]
+
+[project.urls]
+repository = 'https://github.com/SiLab-Bonn/pyLandau'
 
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
     "setuptools",
     "wheel",
-    "numpy>=1.22",
+    "numpy>=1.21",
     "cython>=0.29",
 ]  # PEP 508 specifications
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-numpy>=1.22
-scipy>=1.8
+cython>=0.29
+numpy>=1.21
+scipy>=1.7

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ else:
                                sources=['pyLandau/cpp/pylandau.cpp'],
                                language="c++")]
 
-install_requires = ['numpy>=1.22', 'scipy>=1.8']
+install_requires = ['cython>=0.29', 'numpy>=1.21']
 
 setup(
     cmdclass={'build_ext': build_ext},


### PR DESCRIPTION
- Minor changes on the dependencies to support numpy version 1.21 which is currently the latest supported version in numba. Previously both packages could not coexist in the same environment.
- Add testing of compiled wheels