### PR TITLE
Update packaging

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,35 +3,65 @@ name: Build wheels
 on: [push]
 
 jobs:
-  build:
+  build_wheels:
     name: Build wheels
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      matrix:
+        include:
+          - os: linux-intel
+            runs-on: ubuntu-latest
+          - os: linux-arm
+            runs-on: ubuntu-24.04-arm
+          # - os: windows-intel
+          #   runs-on: windows-latest
+          # - os: windows-arm
+          #   runs-on: windows-11-arm
+          # - os: macos-intel
+          #   # macos-15-intel is the last x86_64 runner
+          #   runs-on: macos-15-intel
+          - os: macos-arm
+            # macos-14+ (including latest) are ARM64 runners
+            runs-on: macos-latest
+
     steps:
     - uses: actions/checkout@v6
-    - name: Setup Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: 3.13
-    - name: Install build
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
 
-    - name: Build
-      run:
-        python3 -m build
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v3.4.1
+      env:
+        CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
+        CIBW_ARCHS: ${{ matrix.archs || 'auto' }}
 
-    - uses: actions/upload-artifact@v7
+    - name: Upload wheel artifact
+      uses: actions/upload-artifact@v4
       with:
-        name: package-dist
-        path: dist
+        name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+        path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - name: Upload sdist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
 
   upload:
     name: Upload wheels and sdist
     runs-on: ubuntu-latest
 
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-    needs: [build]
+    needs: [build_wheels, build_sdist]
     environment:
       name: pypi
       url: https://pypi.org/p/pylandau
@@ -39,10 +69,13 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/download-artifact@v8
-      with:
-        name: package-dist
-        path: dist
-    - uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        verbose: true
+      - uses: actions/download-artifact@v5
+        with:
+          # unpacks all CIBW artifacts into dist/
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v3.4.1
       env:
-        CIBW_SKIP: "cp314-* *-musllinux_*"
+        CIBW_SKIP: "cp314* *-musllinux_*"
         CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
         CIBW_ARCHS: ${{ matrix.archs || 'auto' }}
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v3.4.1
       env:
+        CIBW_SKIP: "cp314-* *-musllinux_*"
         CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
         CIBW_ARCHS: ${{ matrix.archs || 'auto' }}
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -35,7 +35,7 @@ jobs:
         CIBW_ARCHS: ${{ matrix.archs || 'auto' }}
 
     - name: Upload wheel artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
         path: ./wheelhouse/*.whl
@@ -52,7 +52,7 @@ jobs:
         run: pipx run build --sdist
 
       - name: Upload sdist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cibw-sdist
           path: dist/*.tar.gz
@@ -70,7 +70,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8
         with:
           # unpacks all CIBW artifacts into dist/
           pattern: cibw-*


### PR DESCRIPTION
Use cibuildwheel for wheels for different platforms and architectures (due to numba's AOT compilation).